### PR TITLE
feat(cli-show-api-key): adds the option to see your api key

### DIFF
--- a/apps/cli/src/commands/account.ts
+++ b/apps/cli/src/commands/account.ts
@@ -10,7 +10,7 @@ import { ConfigProvider } from 'providers/config/provider'
 export function outputAuthenticationPrompt() {
   logger.log('\n\nYou are not authenticated.')
   logger.log(
-    `Please run ${chalk.bold.blue('onegrep-cli account login')} to authenticate.\n\n`
+    `Please run ${chalk.bold.blue('onegrep-cli account')} and select login to authenticate.\n\n`
   )
 }
 
@@ -43,12 +43,14 @@ async function forceCheckApiUrl(
   if (!currentUrl || forceSet) {
     if (!currentUrl) {
       logger.info(
-        chalk.yellow('API URL is not set. You need to set it before proceeding.')
+        chalk.yellow(
+          'API URL is not set. You need to set it before proceeding.'
+        )
       )
     }
 
     const apiUrl = await input({
-      message: 'Enter the API URL:',
+      message: 'What would you like your API URL to be?',
       default: currentUrl ?? 'https://test-sandbox.onegrep.dev',
       validate: (value) => {
         if (!value.trim()) return 'API URL is required'
@@ -137,31 +139,6 @@ async function handleSetApiKey(params: { configProvider: ConfigProvider }) {
   }
 
   outputApiKeyInstructions()
-}
-
-/**
- * Handles setting the API URL
- */
-async function setOrUpdateApiUrl(params: { configProvider: ConfigProvider }) {
-  try {
-    const currentUrl = params.configProvider.getConfig().identity?.apiUrl
-
-    if (currentUrl) {
-      logger.info(`Current API URL: ${chalk.cyan(currentUrl)}`)
-      const changeUrl = await confirm({
-        message: 'Do you want to change the API URL?',
-        default: false
-      })
-
-      if (!changeUrl) {
-        return
-      }
-    }
-  } catch (error) {
-    logger.error(
-      `Failed to update API URL: ${error instanceof Error ? error.message : String(error)}`
-    )
-  }
 }
 
 async function loginUser(params: {
@@ -295,7 +272,7 @@ async function handleAccountStatus(params: {
   configProvider: ConfigProvider
   authProvider: AuthzProvider
 }) {
-  logger.log('\n\n')
+  clearTerminal()
   const spinner = getSpinner('Checking account status...')
 
   try {
@@ -364,18 +341,13 @@ async function handleAccountStatus(params: {
     if (showApiKey) {
       logger.log(
         chalk.bold.redBright(
-          `WARNING: Keep your API key secret. To prevent it from being stored in your shell history, run:`
+          `[WARNING] Keep your API key secret. To prevent it from being stored in your shell history, run:`
         )
       )
-      logger.log(
-        chalk.red(
-          `export HISTIGNORE="ONEGREP_API_KEY*"\n`
-        )
-      )
+      logger.log(chalk.yellow(`export HISTIGNORE="ONEGREP_API_KEY*"\n`))
 
-      logger.log(`\n\nONEGREP_API_KEY = ${config.identity!.apiKey!}\n\n`)
+      logger.log(`\n\nONEGREP_API_KEY = ${config.identity!.apiKey!}\n`)
     }
-
   } catch (error) {
     // Force stop the spinner in case it's still running
     spinner.stop()
@@ -393,33 +365,32 @@ async function handleAccountSetup(params: {
     clearTerminal()
     logger.info(chalk.bold.blueBright('OneGrep Account Setup'))
 
-    await setOrUpdateApiUrl({ configProvider: params.configProvider })
-
     // Now show the account setup options
     const option = await select({
-      message: 'How would you like to setup your account?',
+      message: 'Account Setup Options',
       choices: [
         {
           name: 'Create a new account (I have an invitation code)',
           value: 'create-account'
         },
         {
-          name: 'I have an API Key',
-          value: 'api-key'
-        },
-        {
           name: 'Update my API URL',
           value: 'api-url'
         },
         {
+          name: 'Use an existing API Key',
+          value: 'api-key'
+        },
+        {
           name: 'Go back',
-          value: 'back'
+          value: 'go-back'
         }
       ]
     })
 
     switch (option) {
       case 'create-account':
+        await forceCheckApiUrl(params.configProvider, true)
         await handleAccountCreation(params)
         await handleAccountStatus({
           configProvider: params.configProvider,
@@ -430,10 +401,9 @@ async function handleAccountSetup(params: {
         await handleSetApiKey(params)
         break
       case 'api-url':
-        await setOrUpdateApiUrl(params)
+        await forceCheckApiUrl(params.configProvider, true)
         break
-      case 'back':
-        logger.info('Operation cancelled.')
+      case 'go-back':
         return
     }
   } catch (error) {
@@ -456,45 +426,59 @@ export function getAccountsCommand(params: {
     'Manage your OneGrep account and authentication'
   )
 
-  // Setup command
-  accountCommand
-    .command('setup')
-    .description('Set up your OneGrep account')
-    .action(async () => {
-      await handleAccountSetup(params)
-    })
+  accountCommand.action(async () => {
+    clearTerminal()
 
-  // Set API URL command
-  accountCommand
-    .command('set-url')
-    .description('Set or update the API URL')
-    .action(async () => {
-      await setOrUpdateApiUrl(params)
-    })
+    while (true) {
+      logger.log(
+        chalk.bold.blueBright(
+          '\n\nSelect an option to manage your OneGrep account\n'
+        )
+      )
+      const option = await select({
+        message: '',
+        choices: [
+          {
+            name: 'Setup or update my account',
+            value: 'setup'
+          },
+          {
+            name: 'See my authentication status',
+            value: 'status'
+          },
+          {
+            name: 'Login',
+            value: 'login'
+          },
+          {
+            name: 'Logout',
+            value: 'logout'
+          },
+          {
+            name: 'Exit',
+            value: 'exit'
+          }
+        ]
+      })
 
-  // Login command
-  accountCommand
-    .command('login')
-    .description('Authenticate with OneGrep')
-    .action(async () => {
-      await handleLogin(params)
-    })
-
-  // Logout command
-  accountCommand
-    .command('logout')
-    .description('Log out from OneGrep')
-    .action(async () => {
-      await handleLogout(params)
-    })
-
-  // Status command to view account details
-  accountCommand
-    .command('status')
-    .description('View your account status and details')
-    .action(async () => {
-      await handleAccountStatus(params)
-    })
+      switch (option) {
+        case 'setup':
+          await handleAccountSetup(params)
+          break
+        case 'status':
+          await handleAccountStatus(params)
+          break
+        case 'login':
+          await handleLogin(params)
+          break
+        case 'logout':
+          await handleLogout(params)
+          break
+        case 'exit':
+          process.exit(0)
+      }
+    }
+  })
 
   return accountCommand
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -23,9 +23,9 @@ async function validateAuthenticationState(authProvider: AuthzProvider) {
   } catch (error) {
     logger.debug(`Authentication check failed: ${error}`)
     logger.log(
-      'Authentication check failed. Run the following command to set up your account:'
+      'Authentication check failed. Run the following command to setup your account:'
     )
-    logger.log(`$> ${chalk.bold.green('onegrep-cli')} account setup\n\n`)
+    logger.log(`$> ${chalk.bold.green('onegrep-cli')} account\n\n`)
   }
 }
 
@@ -78,7 +78,7 @@ async function main() {
   } catch (err) {
     logger.error(`Error setting up CLI: ${err}`)
     logger.log(
-      `If you are running into authentication issues, run ${chalk.bold.blue('onegrep-cli account setup')} to setup your environment.`
+      `If you are running into authentication issues, run ${chalk.bold.blue('onegrep-cli account')} and select setup to configure your environment.`
     )
     process.exit(1)
   }


### PR DESCRIPTION
**Features**
- See your api key by selecting the `status` option in `onegrep-cli account`.
- Changes account commands to be a multi-select input rather `onegrep-cli account <subcommand>` just run `onegrep-cli account`.

**Bug fixes**
- fixes bug where you couldn't update your api url after selecting that option on account management