### PR TITLE
chore: wrap console logger with root

### DIFF
--- a/justfile
+++ b/justfile
@@ -82,13 +82,12 @@ dev-n8n:
 # tail all onegrep logs
 [group('logs')]
 tail-logs:
-    tail -f ~/.onegrep/*.log
+    multitail -q 1 ~/.onegrep/*.log
 
 # tail the sdk log
 [group('logs')]
 tail-sdk-logs:
-    touch ~/.onegrep/onegrep.sdk.log
-    tail -f ~/.onegrep/onegrep.sdk.log
+    tail -F ~/.onegrep/onegrep.sdk.log
 
 # clear logs
 [group('logs')]

--- a/packages/onegrep-sdk/package.json
+++ b/packages/onegrep-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onegrep/sdk",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "license": "MIT",
   "author": "OneGrep, Inc.",

--- a/packages/onegrep-sdk/src/core/api/client.test.ts
+++ b/packages/onegrep-sdk/src/core/api/client.test.ts
@@ -1,9 +1,9 @@
 import { clientFromConfig } from './client.js'
 import { describe, it, expect } from 'vitest'
 
-import { getLogger } from '@repo/utils'
+import { testLog } from '../../../test/log.test.js'
 
-const log = getLogger('console', 'test')
+const log = testLog
 
 describe('API Client Integration Tests', () => {
   it.skip('should successfully call the health endpoint', async () => {

--- a/packages/onegrep-sdk/src/extensions/langchain.test.ts
+++ b/packages/onegrep-sdk/src/extensions/langchain.test.ts
@@ -2,13 +2,13 @@ import { describe, it, expect, beforeAll } from 'vitest'
 import { createLangchainToolbox, LangchainToolbox } from './langchain.js'
 import { ToolInputParsingException } from '@langchain/core/tools'
 
-import { createToolbox, Toolbox } from '~/toolbox.js'
-import { clientFromConfig } from '~/core/api/client.js'
-import { FilterOptions, ToolCallOutput } from '~/types.js'
+import { createToolbox, Toolbox } from '../toolbox.js'
+import { clientFromConfig } from '../core/api/client.js'
+import { FilterOptions, ToolCallOutput } from '../types.js'
 
-import { getLogger } from '@repo/utils'
+import { testLog } from '../../test/log.test.js'
 
-const log = getLogger('console', 'test')
+const log = testLog
 
 describe('Langchain Toolbox Tests', () => {
   let toolbox: Toolbox

--- a/packages/onegrep-sdk/src/toolbox.test.ts
+++ b/packages/onegrep-sdk/src/toolbox.test.ts
@@ -12,11 +12,11 @@ import {
 
 import 'dotenv/config'
 
-import { getLogger } from '@repo/utils'
-
 import { fail } from 'assert'
 
-const log = getLogger('console', 'test')
+import { testLog } from '../test/log.test.js'
+
+const log = testLog
 
 describe('Base Toolbox Tests', () => {
   let toolbox: Toolbox

--- a/packages/onegrep-sdk/src/toolbox.ts
+++ b/packages/onegrep-sdk/src/toolbox.ts
@@ -16,7 +16,6 @@ import { getDopplerSecretManager } from './secrets/doppler.js'
 
 import { createToolCache } from '~/toolcache.js'
 
-import { log } from '~/core/log.js'
 import {
   apiKeyBlaxelClientSessionMaker,
   apiKeySmitheryClientSessionMaker,
@@ -24,6 +23,8 @@ import {
 } from './connection.js'
 import { ClientSessionMaker } from './connection.js'
 import { SecretManager } from './secrets/index.js'
+
+import { log } from '~/core/log.js'
 
 export class Toolbox implements BaseToolbox<ToolDetails> {
   apiClient: OneGrepApiClient

--- a/packages/onegrep-sdk/src/toolcache.test.ts
+++ b/packages/onegrep-sdk/src/toolcache.test.ts
@@ -2,6 +2,11 @@ import { clientFromConfig } from './core/index.js'
 import { UniversalToolCache } from './toolcache.js'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { ToolServerConnectionManager } from './connection.js'
+
+import { testLog } from '../test/log.test.js'
+
+const log = testLog
+
 // import { SecretManager } from '~/secrets/index.js'
 
 // class MockSecretManager implements SecretManager {

--- a/packages/onegrep-sdk/src/toolcache.ts
+++ b/packages/onegrep-sdk/src/toolcache.ts
@@ -30,8 +30,9 @@ import { Keyv } from 'keyv'
 import { Cache, createCache } from 'cache-manager'
 import { ToolServerConnectionManager } from '~/connection.js'
 
-import { log } from '~/core/log.js'
 import { OneGrepApiError } from './core/api/utils.js'
+
+import { log } from '~/core/log.js'
 
 /**
  * A wrapper around a ToolHandle that provides a safe way to call the tool.
@@ -292,7 +293,7 @@ export class UniversalToolCache implements ToolCache {
   @handleErrors()
   async listTools(): Promise<Map<ToolId, BasicToolDetails>> {
     const tools: Tool[] = await this.highLevelClient.listTools()
-    console.debug(`Found ${tools.length} tools`)
+    log.debug(`Found ${tools.length} tools`)
 
     const basicTools: Map<ToolId, BasicToolDetails> = new Map()
 
@@ -330,9 +331,7 @@ export class UniversalToolCache implements ToolCache {
   async filterTools(
     filterOptions?: FilterOptions
   ): Promise<Map<ToolId, ToolDetails>> {
-    console.info(
-      `Filtering tools with options: ${JSON.stringify(filterOptions)}`
-    )
+    log.info(`Filtering tools with options: ${JSON.stringify(filterOptions)}`)
     if (!filterOptions) {
       throw new Error(
         'No filter options provided. If you want to list tools, use the `.listTools()` method.'

--- a/packages/onegrep-sdk/test/log.test.ts
+++ b/packages/onegrep-sdk/test/log.test.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+import { loggingSchema, getEnv, getLogger } from '@repo/utils'
+
+const testLogLevel = () => {
+  return process.env.ONEGREP_SDK_TEST_LOG_LEVEL ?? 'debug'
+}
+
+const initTestLogger = () => {
+  const env = getEnv(loggingSchema)
+
+  return getLogger(env.LOG_MODE, 'test', testLogLevel())
+}
+
+/**
+ * The child logger for test files.
+ */
+export const testLog = initTestLogger()

--- a/packages/utils/src/loggers/file.ts
+++ b/packages/utils/src/loggers/file.ts
@@ -73,7 +73,8 @@ export function fileLogger(
   }
 
   // Construct the log file path based on the logger name
-  let logFilepath = getLogFilepath('onegrep.log')
+  // Console is considered the root logger
+  let logFilepath = getLogFilepath('console.log')
   if (loggerName) {
     logFilepath = getLogFilepath(`onegrep.${loggerName}.log`)
   }


### PR DESCRIPTION
In 'file' log mode, we want to ensure we're in full control of everything that goes to stdout, so any dependencies (like blaxel) write directly to the default console, we need to ensure that doesn't show up in the CLI menus etc.

Replace the default console with our root logger if in file mode.  If not in file mode, just let it through to the console as normal. Similar with all mode.