### PR TITLE
feat: LaunchConfig models for Smithery Transports

### DIFF
--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ reinstall:
 # generate code for all packages
 [group('generate')]
 generate:
-    pnpm turbo run generate
+    pnpm turbo run generate --force
     ./fix-api-client.sh # ! There's a bug in the api client generator for discriminated unions
 
 # prettier format code for all packages

--- a/packages/onegrep-api-client/openapi/onegrep-api.yaml
+++ b/packages/onegrep-api-client/openapi/onegrep-api.yaml
@@ -1075,6 +1075,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/servers/{server_id}/properties:
+    get:
+      tags:
+        - servers
+      summary: Get Server Properties
+      operationId: get_server_properties_api_v1_servers__server_id__properties_get
+      security:
+        - APIKeyHeader: []
+        - HTTPBearer: []
+      parameters:
+        - name: server_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Server Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolServerProperties'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /api/v1/servers/{server_id}/properties/{key}:
+    patch:
+      tags:
+        - servers
+      summary: Patch Server Properties
+      operationId: >-
+        patch_server_properties_api_v1_servers__server_id__properties__key__patch
+      security:
+        - APIKeyHeader: []
+        - HTTPBearer: []
+      parameters:
+        - name: server_id
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Server Id
+        - name: key
+          in: path
+          required: true
+          schema:
+            type: string
+            title: Key
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              title: Value
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ToolServerProperties'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /api/v1/servers/{server_id}/client:
     get:
       tags:
@@ -2800,6 +2872,10 @@ components:
             $ref: '#/components/schemas/SmitheryConnectionInfo'
           type: array
           title: Connections
+        launch_config:
+          anyOf:
+            - $ref: '#/components/schemas/ToolServerLaunchConfig'
+            - type: 'null'
       type: object
       required:
         - server_id
@@ -3032,6 +3108,31 @@ components:
         - name
         - id
       title: ToolServer
+    ToolServerLaunchConfig:
+      properties:
+        source:
+          type: string
+          const: doppler
+          title: Source
+        secret_name:
+          type: string
+          title: Secret Name
+      type: object
+      required:
+        - source
+        - secret_name
+      title: ToolServerLaunchConfig
+      description: The launch config for a tool server.
+    ToolServerProperties:
+      properties:
+        properties:
+          type: object
+          title: Properties
+      type: object
+      required:
+        - properties
+      title: ToolServerProperties
+      description: Properties for a tool server.
     ToolServerProvider:
       properties:
         id:

--- a/packages/onegrep-api-client/src/api.ts
+++ b/packages/onegrep-api-client/src/api.ts
@@ -122,6 +122,9 @@ type SmitheryToolServerClient = {
   server_id: string
   client_type: string
   connections: Array<SmitheryConnectionInfo>
+  launch_config?:
+    | ((ToolServerLaunchConfig | null) | Array<ToolServerLaunchConfig | null>)
+    | undefined
 }
 type SmitheryConnectionInfo = {
   /**
@@ -138,6 +141,10 @@ type SmitheryConnectionInfo = {
      */
     (({} | boolean) | Array<{} | boolean>)
     | undefined
+}
+type ToolServerLaunchConfig = {
+  source: string
+  secret_name: string
 }
 type ToolServerProvider = {
   id: string
@@ -939,6 +946,10 @@ const Strategy: z.ZodType<Strategy> = z
   })
   .strict()
   .passthrough()
+const ToolServerProperties = z
+  .object({ properties: z.object({}).partial().strict().passthrough() })
+  .strict()
+  .passthrough()
 const MCPToolServerClient: z.ZodType<MCPToolServerClient> = z
   .object({
     server_id: z.string().uuid(),
@@ -968,11 +979,16 @@ const SmitheryConnectionInfo: z.ZodType<SmitheryConnectionInfo> = z
   })
   .strict()
   .passthrough()
+const ToolServerLaunchConfig: z.ZodType<ToolServerLaunchConfig> = z
+  .object({ source: z.string(), secret_name: z.string() })
+  .strict()
+  .passthrough()
 const SmitheryToolServerClient: z.ZodType<SmitheryToolServerClient> = z
   .object({
     server_id: z.string().uuid(),
     client_type: z.string(),
-    connections: z.array(SmitheryConnectionInfo)
+    connections: z.array(SmitheryConnectionInfo),
+    launch_config: z.union([ToolServerLaunchConfig, z.null()]).optional()
   })
   .strict()
   .passthrough()
@@ -1252,9 +1268,11 @@ export const schemas = {
   RecipeDetails_Input,
   NewUserRecipeRequest,
   Strategy,
+  ToolServerProperties,
   MCPToolServerClient,
   BlaxelToolServerClient,
   SmitheryConnectionInfo,
+  ToolServerLaunchConfig,
   SmitheryToolServerClient,
   Policy,
   NewPolicyRequest,
@@ -2158,6 +2176,65 @@ along with a similarity score for each tool.`,
       BlaxelToolServerClient,
       SmitheryToolServerClient
     ]),
+    errors: [
+      {
+        status: 422,
+        description: `Validation Error`,
+        schema: HTTPValidationError
+      }
+    ]
+  },
+  {
+    method: 'get',
+    path: '/api/v1/servers/:server_id/properties',
+    alias: 'get_server_properties_api_v1_servers__server_id__properties_get',
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'server_id',
+        type: 'Path',
+        schema: z.string()
+      }
+    ],
+    response: z
+      .object({ properties: z.object({}).partial().strict().passthrough() })
+      .strict()
+      .passthrough(),
+    errors: [
+      {
+        status: 422,
+        description: `Validation Error`,
+        schema: HTTPValidationError
+      }
+    ]
+  },
+  {
+    method: 'patch',
+    path: '/api/v1/servers/:server_id/properties/:key',
+    alias:
+      'patch_server_properties_api_v1_servers__server_id__properties__key__patch',
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'body',
+        type: 'Body',
+        schema: z.object({}).partial().strict().passthrough()
+      },
+      {
+        name: 'server_id',
+        type: 'Path',
+        schema: z.string()
+      },
+      {
+        name: 'key',
+        type: 'Path',
+        schema: z.string()
+      }
+    ],
+    response: z
+      .object({ properties: z.object({}).partial().strict().passthrough() })
+      .strict()
+      .passthrough(),
     errors: [
       {
         status: 422,

--- a/packages/onegrep-sdk/package.json
+++ b/packages/onegrep-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onegrep/sdk",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "type": "module",
   "license": "MIT",
   "author": "OneGrep, Inc.",

--- a/packages/onegrep-sdk/src/core/api/types.ts
+++ b/packages/onegrep-sdk/src/core/api/types.ts
@@ -18,6 +18,9 @@ export type BlaxelToolServerClient = z.infer<
 export type SmitheryToolServerClient = z.infer<
   typeof schemas.SmitheryToolServerClient
 >
+export type ToolServerLaunchConfig = z.infer<
+  typeof schemas.ToolServerLaunchConfig
+>
 
 export type ToolServerClient =
   | MCPToolServerClient

--- a/packages/onegrep-sdk/src/providers/blaxel/settings.ts
+++ b/packages/onegrep-sdk/src/providers/blaxel/settings.ts
@@ -2,7 +2,7 @@ import os from 'os'
 import fs from 'fs'
 import { join } from 'path'
 
-import { settings as blaxelSettings } from '@blaxel/sdk'
+import { settings as blaxelSettings } from '@blaxel/core'
 
 import { getDopplerSecretManager } from '~/secrets/doppler.js'
 

--- a/packages/onegrep-sdk/src/secrets/doppler.ts
+++ b/packages/onegrep-sdk/src/secrets/doppler.ts
@@ -142,6 +142,11 @@ export class DopplerSecretManager implements SecretManager {
     return Array.from(secretsMap.keys())
   }
 
+  async hasSecret(secretName: string): Promise<boolean> {
+    const secretsMap = await this.fetchSecrets()
+    return secretsMap.has(secretName)
+  }
+
   async getSecret(secretName: string): Promise<string> {
     const secretsMap = await this.fetchSecrets()
     const secretValue = secretsMap.get(secretName)

--- a/packages/onegrep-sdk/src/secrets/types.ts
+++ b/packages/onegrep-sdk/src/secrets/types.ts
@@ -1,6 +1,7 @@
 export interface SecretManager {
   initialize(): Promise<void>
   getSecretNames(): Promise<string[]>
+  hasSecret(secretName: string): Promise<boolean>
   getSecret(secretName: string): Promise<string>
   getSecrets(
     secretNames: string[],

--- a/packages/onegrep-sdk/src/toolbox.test.ts
+++ b/packages/onegrep-sdk/src/toolbox.test.ts
@@ -319,4 +319,37 @@ describe('Smithery Toolbox Tests', () => {
 
     await new Promise((resolve) => setTimeout(resolve, 1000))
   })
+
+  it('should be able to make a tool call with valid input and server config', async () => {
+    const toolDetails = await toolbox.get(
+      'a029eb98-b9f6-54e5-95c9-c4586fad0e4d'
+    ) // ! @flrngel/mcp-painter
+    expect(toolDetails).toBeDefined()
+    log.info(`found tool: ${toolDetails.name}`)
+
+    const tool: EquippedTool = await toolDetails.equip()
+    expect(tool).toBeDefined()
+    if (!tool) {
+      throw new Error('Tool not found')
+    }
+    log.info(`equipped tool: ${tool.details.name}`)
+
+    const args = {
+      width: 100,
+      height: 100
+    }
+
+    const response: ToolCallResponse<any> = await tool.handle.call({
+      args: args,
+      approval: undefined
+    })
+    expect(response).toBeDefined()
+    expect(response).toBeTypeOf('object')
+    expect(response.isError).toBe(false)
+
+    const output = response as ToolCallOutput<any>
+    log.info(`Output: ${JSON.stringify(output)}`)
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+  })
 })

--- a/packages/onegrep-sdk/src/toolbox.ts
+++ b/packages/onegrep-sdk/src/toolbox.ts
@@ -96,6 +96,7 @@ const registerSessionMakers = async (secretManager: SecretManager) => {
   // Smithery provider requires an API key
   if (secrets.has('SMITHERY_API_KEY')) {
     const smitherySessionMaker = apiKeySmitheryClientSessionMaker(
+      secretManager,
       secrets.get('SMITHERY_API_KEY')!
     )
     defaultToolServerSessionFactory.register(


### PR DESCRIPTION
# Pull Request Description

Adds support for `LaunchConfig` data to be vended via secrets in the Secrets Manager. Used for Smithery Transport connections.

## Type of Change

<!-- Please check the one that applies to this PR using "x". -->

- [x] 🚀 New Features
- [ ] 🐛 Bug Fixes
- [ ] 💡 Other Enhancements
- [ ] 📚 Documentation Updates
- [ ] 🔧 Configuration Changes
- [ ] ⚡ Performance Improvements

## Description

Smithery requires the MCP server configuration to be passed into the connection string each time, so we need a way to store it server-side and let the SDK fetch it as needed.  Using secrets because often the configuration includes API key credentials to connect to external services.

## Breaking Changes

Requires new API endpoints, but does not have breaking API client model changes.

Does not change anything for Blaxel session makers, but adds new logic to Smithery session makers.

## Testing

Local testing against servers from both providers

## Checklist

<!-- Please check all that apply -->

- [x] I have run all tests
- [x] I have cleaned/installed/built the project
- [ ] This PR requires a new release (optional)
- [ ] I have added/updated documentation
- [x] My changes follow the project's coding standards
- [x] I have added appropriate tests for my changes
- [x] All existing tests are passing
