### PR TITLE
fix: remove default flag provider

### DIFF
--- a/packages/onegrep-sdk/package.json
+++ b/packages/onegrep-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onegrep/sdk",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "license": "MIT",
   "author": "OneGrep, Inc.",

--- a/packages/onegrep-sdk/src/core/flags.test.ts
+++ b/packages/onegrep-sdk/src/core/flags.test.ts
@@ -1,13 +1,11 @@
 import { describe, it, expect } from 'vitest'
 
-import { flags } from './flags.js'
-
 import { testLog } from '../../test/log.test.js'
 
 const log = testLog
 
 import { OneGrepApiHighLevelClient } from './api/high.js'
-import { FlagsProvider } from './flags.js'
+import { FlagsProvider, getFlagsProvider } from './flags.js'
 
 class MockHighLevelClient extends OneGrepApiHighLevelClient {
   constructor() {
@@ -33,7 +31,7 @@ class MockHighLevelClient extends OneGrepApiHighLevelClient {
   }
 }
 
-const flagsProvider = new FlagsProvider(new MockHighLevelClient())
+const flagsProvider = getFlagsProvider(new MockHighLevelClient())
 
 describe('FlagsProvider', () => {
   it('should get flags', async () => {

--- a/packages/onegrep-sdk/src/core/flags.ts
+++ b/packages/onegrep-sdk/src/core/flags.ts
@@ -1,6 +1,5 @@
 import { Keyv } from 'keyv'
 import { Cache, createCache } from 'cache-manager'
-import { clientFromConfig } from './api/client.js'
 import { OneGrepApiHighLevelClient } from './api/high.js'
 import { log } from './log.js'
 
@@ -50,6 +49,8 @@ export class FlagsProvider {
   }
 }
 
-export const flags = new FlagsProvider(
-  new OneGrepApiHighLevelClient(clientFromConfig())
-)
+export const getFlagsProvider = (
+  apiClient: OneGrepApiHighLevelClient
+): FlagsProvider => {
+  return new FlagsProvider(apiClient)
+}


### PR DESCRIPTION
# Pull Request Description

Removes the automatically initialized default flag provider.

## Type of Change

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 🚀 New Features
- [x] 🐛 Bug Fixes
- [ ] 💡 Other Enhancements
- [ ] 📚 Documentation Updates
- [ ] 🔧 Configuration Changes
- [ ] ⚡ Performance Improvements

## Description

As an SDK, we don't want to force a default FlagsProvider simply by including the package as the consumer might not be authenticated with an API key yet.

## Bug Fixes

Consumers won't error out on package inclusion if not authenticated.

## Testing

CLI usage

## Checklist

<!-- Please check all that apply -->

- [x] I have run all tests
- [x] I have cleaned/installed/built the project
- [x] This PR requires a new release (optional)
- [ ] I have added/updated documentation
- [x] My changes follow the project's coding standards
- [x] I have added appropriate tests for my changes
- [x] All existing tests are passing

