### PR TITLE
fix(lazyload-composio): changes loading pattern of composio to be lazy loaded

### DIFF
--- a/packages/onegrep-sdk/package.json
+++ b/packages/onegrep-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onegrep/sdk",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "type": "module",
   "license": "MIT",
   "author": "OneGrep, Inc.",

--- a/packages/onegrep-sdk/src/providers/composio/api.ts
+++ b/packages/onegrep-sdk/src/providers/composio/api.ts
@@ -1,15 +1,28 @@
 import { Composio, ComposioToolSet } from 'composio-core'
 
-export const composio = new Composio({
-  apiKey: process.env.COMPOSIO_API_KEY, // Required
-  baseUrl: 'https://backend.composio.dev', // Optional, defaults to production URL
-  runtime: 'nodejs', // Optional, helps with telemetry
-  allowTracing: true // Optional, enables tracing
-})
+let _composio: Composio | undefined
+let _composioToolSet: ComposioToolSet | undefined
 
-export const composioToolSet = new ComposioToolSet({
-  apiKey: process.env.COMPOSIO_API_KEY,
-  baseUrl: 'https://backend.composio.dev',
-  runtime: 'nodejs',
-  allowTracing: true
-})
+export function getComposio(apiKey: string): Composio {
+  if (!_composio) {
+    _composio = new Composio({
+      apiKey,
+      baseUrl: 'https://backend.composio.dev',
+      runtime: 'nodejs',
+      allowTracing: true
+    })
+  }
+  return _composio
+}
+
+export function getComposioToolSet(apiKey: string): ComposioToolSet {
+  if (!_composioToolSet) {
+    _composioToolSet = new ComposioToolSet({
+      apiKey,
+      baseUrl: 'https://backend.composio.dev',
+      runtime: 'nodejs',
+      allowTracing: true
+    })
+  }
+  return _composioToolSet
+}


### PR DESCRIPTION
# Pull Request Description

## Type of Change

- [ ] 🚀 New Features
- [x] 🐛 Bug Fixes
- [ ] 💡 Other Enhancements
- [ ] 📚 Documentation Updates
- [ ] 🔧 Configuration Changes
- [ ] ⚡ Performance Improvements

## Description

- Changes composio integration to be lazy loaded. If credentials were not present before it would cause agents to fail.

## Testing

- Tested using the `apps/examples/langchain/chat-agent` loop with just an openai key.

## Checklist

- [ ] I have run all tests
- [x] I have cleaned/installed/built the project
- [ ] This PR requires a new release (optional)
- [ ] I have added/updated documentation
- [x] My changes follow the project's coding standards
- [ ] I have added appropriate tests for my changes
- [ ] All existing tests are passing