### PR TITLE
fix: use same api client for default secret manager

### DIFF
--- a/packages/onegrep-sdk/package.json
+++ b/packages/onegrep-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onegrep/sdk",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "type": "module",
   "license": "MIT",
   "author": "OneGrep, Inc.",

--- a/packages/onegrep-sdk/src/toolbox.ts
+++ b/packages/onegrep-sdk/src/toolbox.ts
@@ -14,7 +14,7 @@ import {
   BasicToolDetails,
   Recommendation
 } from '~/types.js'
-import { getDopplerSecretManager } from './secrets/doppler.js'
+import { createDopplerSecretManager } from './secrets/doppler.js'
 
 import { createToolCache } from '~/toolcache.js'
 
@@ -151,7 +151,7 @@ export async function createToolbox(
 ) {
   // Make sure the secret manager is initialized
   const secretManager =
-    providedSecretManager ?? (await getDopplerSecretManager())
+    providedSecretManager ?? (await createDopplerSecretManager(apiClient))
   await secretManager.initialize()
 
   // Register available session makers


### PR DESCRIPTION
# Pull Request Description

Uses same api client so we don't error out if API KEY env var not set.

## Type of Change

<!-- Please check the one that applies to this PR using "x". -->

- [ ] 🚀 New Features
- [x] 🐛 Bug Fixes
- [ ] 💡 Other Enhancements
- [ ] 📚 Documentation Updates
- [ ] 🔧 Configuration Changes
- [ ] ⚡ Performance Improvements
